### PR TITLE
feat: domain classification + web UI

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -1,0 +1,30 @@
+# Plan: Interactsh Domain Classification + Web Interface
+
+## Original Intent
+
+Add version/client classification (v1.0.1 vs v1.0.2+, CLI vs web), accept web-client domains that are currently silently rejected, decode v1.0.1 nonces for session analytics, and provide a web UI for analysts without CLI access. The user provided a detailed 12-step implementation plan covering zbase32 decoding, classification engine, extended validation, decoder updates, campaign analysis, CLI output, MCP tools, and a full embedded web interface.
+
+## Status: In Progress
+
+## Context
+
+go-roast decodes Interactsh OAST domain metadata from CLI-generated domains, but has three gaps:
+
+1. **No version/client classification** - Cannot distinguish v1.0.1 from v1.0.2+, nor CLI from web client origins.
+2. **Web client domains silently rejected** - `IsValidPreamble()` only accepts `[0-9a-v]`, but web client generates `[a-z]`.
+3. **No web UI** - Analysts without CLI access cannot use the tool.
+
+## Steps
+
+1. zbase32 decoder (`pkg/roast/zbase32.go`)
+2. Classification engine (`pkg/roast/classify.go`)
+3. Wire classification into types (`pkg/roast/types.go`)
+4. Broaden extraction regex (`pkg/roast/extractor.go`)
+5. Extended validation (`pkg/roast/validate.go`)
+6. Update decoder (`pkg/roast/decoder.go`)
+7. Update campaign analysis (`pkg/roast/analyze.go`)
+8. Update existing tests
+9. Update CLI output (`cmd/roast/main.go`)
+10. MCP integration (`mcp/tools.go`, `mcp/server.go`)
+11. Web interface (`web/`)
+12. justfile updates

--- a/cmd/roast/main.go
+++ b/cmd/roast/main.go
@@ -10,6 +10,7 @@ import (
 
 	"codeberg.org/hrbrmstr/go-roast/mcp"
 	"codeberg.org/hrbrmstr/go-roast/pkg/roast"
+	"codeberg.org/hrbrmstr/go-roast/web"
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +36,7 @@ func main() {
 	rootCmd.AddCommand(analyzeCmd())
 	rootCmd.AddCommand(pipeCmd())
 	rootCmd.AddCommand(mcpCmd())
+	rootCmd.AddCommand(serveCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -310,6 +312,25 @@ func mcpCmd() *cobra.Command {
 	}
 }
 
+func serveCmd() *cobra.Command {
+	var addr string
+	var port int
+
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start web UI server",
+		Long:  "Start the web interface for decoding and analyzing OAST domains.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return web.Serve(addr, port)
+		},
+	}
+
+	cmd.Flags().StringVar(&addr, "addr", "127.0.0.1", "Listen address")
+	cmd.Flags().IntVar(&port, "port", 8080, "Listen port")
+
+	return cmd
+}
+
 func outputResults(results []*roast.DecodedOAST, format string) error {
 	switch strings.ToLower(format) {
 	case "json":
@@ -373,12 +394,20 @@ func outputCSV(results []*roast.DecodedOAST) error {
 
 	if err := w.Write([]string{
 		"Original", "Valid", "Timestamp", "MachineID", "PID", "Counter",
-		"KSort", "Campaign", "Nonce", "Error",
+		"KSort", "Campaign", "Nonce", "ClientType", "ServerVersion", "Decodable", "Confidence", "Error",
 	}); err != nil {
 		return err
 	}
 
 	for _, r := range results {
+		clientType, serverVersion, decodable, confidence := "", "", "", ""
+		if r.Classification != nil {
+			clientType = string(r.Classification.ClientType)
+			serverVersion = string(r.Classification.ServerVersion)
+			decodable = fmt.Sprintf("%t", r.Classification.Decodable)
+			confidence = r.Classification.Confidence
+		}
+
 		if err := w.Write([]string{
 			r.Original,
 			fmt.Sprintf("%t", r.Valid),
@@ -389,6 +418,10 @@ func outputCSV(results []*roast.DecodedOAST) error {
 			r.KSort,
 			r.Campaign,
 			r.Nonce,
+			clientType,
+			serverVersion,
+			decodable,
+			confidence,
 			r.Error,
 		}); err != nil {
 			return err
@@ -399,9 +432,9 @@ func outputCSV(results []*roast.DecodedOAST) error {
 }
 
 func outputTable(results []*roast.DecodedOAST) error {
-	fmt.Printf("%-40s %-6s %-20s %-12s %-7s %-10s %-10s %-10s\n",
-		"Original", "Valid", "Timestamp", "MachineID", "PID", "Counter", "KSort", "Campaign")
-	fmt.Println(strings.Repeat("-", 140))
+	fmt.Printf("%-40s %-6s %-20s %-12s %-7s %-10s %-8s %-8s %-8s %-20s %-13s\n",
+		"Original", "Valid", "Timestamp", "MachineID", "PID", "Counter", "Client", "Version", "Conf", "Nonce-Timestamp", "Nonce-Counter")
+	fmt.Println(strings.Repeat("-", 180))
 
 	for _, r := range results {
 		status := "✓"
@@ -414,15 +447,31 @@ func outputTable(results []*roast.DecodedOAST) error {
 			timestamp = ""
 		}
 
-		fmt.Printf("%-40s %-6s %-20s %-12s %-7d %-10d %-10s %-10s\n",
+		clientType, version, conf := "", "", ""
+		nonceTs, nonceCtr := "", ""
+		if r.Classification != nil {
+			clientType = string(r.Classification.ClientType)
+			version = string(r.Classification.ServerVersion)
+			conf = r.Classification.Confidence
+			if r.Classification.NonceAnalysis != nil {
+				na := r.Classification.NonceAnalysis
+				nonceTs = na.NonceTimestamp.Format("2006-01-02 15:04:05")
+				nonceCtr = fmt.Sprintf("%d", na.NonceCounter)
+			}
+		}
+
+		fmt.Printf("%-40s %-6s %-20s %-12s %-7d %-10d %-8s %-8s %-8s %-20s %-13s\n",
 			truncate(r.Original, 40),
 			status,
 			timestamp,
 			r.MachineID,
 			r.PID,
 			r.Counter,
-			r.KSort,
-			r.Campaign,
+			clientType,
+			version,
+			conf,
+			nonceTs,
+			nonceCtr,
 		)
 
 		if r.Error != "" {

--- a/justfile
+++ b/justfile
@@ -98,6 +98,18 @@ test-extract:
     @echo "Testing extract command..."
     @echo "Found: c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro" | ./{{binary}} extract --decode -o json | jq .
 
+# Test classification engine
+test-classify:
+    go test -v -run TestClassify ./pkg/roast/
+
+# Test web handlers
+test-web:
+    go test -v ./web/
+
+# Start web UI server
+serve: build
+    ./{{binary}} serve
+
 # Run all functional tests
 test-all: test test-decode test-extract test-mcp
     @echo "✓ All tests passed"

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -56,6 +56,7 @@ func Serve() error {
 
 	// Register tools
 	s.AddTool(decodeOASTTool(), handleDecodeOAST)
+	s.AddTool(classifyOASTTool(), handleClassifyOAST)
 	s.AddTool(extractOASTTool(), handleExtractOAST)
 	s.AddTool(extractOASTFileTool(), handleExtractOASTFile)
 	s.AddTool(validateOASTTool(), handleValidateOAST)

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -55,6 +55,51 @@ func handleDecodeOAST(args map[string]interface{}) (*mcp.CallToolResult, error) 
 	return mcp.NewToolResultText(string(data)), nil
 }
 
+func classifyOASTTool() mcp.Tool {
+	return mcp.NewTool("classify_oast",
+		mcp.WithDescription("Classify an OAST domain by client type (CLI/web) and server version (v1.0.1/v1.0.2+) without full decode"),
+		mcp.WithString("domain",
+			mcp.Required(),
+			mcp.Description("OAST domain to classify (subdomain or full FQDN)"),
+		),
+	)
+}
+
+func handleClassifyOAST(args map[string]interface{}) (*mcp.CallToolResult, error) {
+	domain, ok := args["domain"].(string)
+	if !ok {
+		return mcp.NewToolResultError("domain must be a string"), nil
+	}
+
+	// Extract subdomain
+	subdomain := domain
+	if idx := strings.Index(domain, "."); idx > 0 {
+		subdomain = domain[:idx]
+	}
+	subdomain = strings.ToLower(subdomain)
+
+	// Try decode to get CID timestamp for nonce analysis
+	decoded, _ := roast.Decode(domain)
+	var cidTimestamp time.Time
+	if decoded != nil && decoded.Valid {
+		cidTimestamp = decoded.Timestamp
+	}
+
+	classification := roast.ClassifyDomain(subdomain, cidTimestamp)
+
+	result := map[string]interface{}{
+		"domain":         domain,
+		"classification": classification,
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to encode results: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(string(data)), nil
+}
+
 func extractOASTTool() mcp.Tool {
 	return mcp.NewTool("extract_oast",
 		mcp.WithDescription("Extract OAST domains from text"),

--- a/pkg/roast/analyze.go
+++ b/pkg/roast/analyze.go
@@ -9,15 +9,17 @@ import (
 
 // CampaignStats contains statistics for a specific campaign
 type CampaignStats struct {
-	CampaignID   string    `json:"campaign_id"`
-	Count        int       `json:"count"`
-	FirstSeen    time.Time `json:"first_seen"`
-	LastSeen     time.Time `json:"last_seen"`
-	MachineIDs   []string  `json:"machine_ids"`
-	PIDs         []uint16  `json:"pids"`
-	CounterMin   uint32    `json:"counter_min"`
-	CounterMax   uint32    `json:"counter_max"`
-	KSortValues  []string  `json:"ksort_values"`
+	CampaignID     string                   `json:"campaign_id"`
+	Count          int                      `json:"count"`
+	FirstSeen      time.Time                `json:"first_seen"`
+	LastSeen       time.Time                `json:"last_seen"`
+	MachineIDs     []string                 `json:"machine_ids"`
+	PIDs           []uint16                 `json:"pids"`
+	CounterMin     uint32                   `json:"counter_min"`
+	CounterMax     uint32                   `json:"counter_max"`
+	KSortValues    []string                 `json:"ksort_values"`
+	ClientTypes    map[ClientType]int       `json:"client_types,omitempty"`
+	ServerVersions map[ServerVersion]int    `json:"server_versions,omitempty"`
 }
 
 // CampaignAnalysis contains the full analysis of OAST domains
@@ -34,6 +36,8 @@ type CampaignAnalysis struct {
 	MachineIDs      []string                 `json:"machine_ids"`
 	PIDs            []uint16                 `json:"pids"`
 	Campaigns       map[string]*CampaignStats `json:"campaigns"`
+	ClientTypes     map[ClientType]int        `json:"client_types,omitempty"`
+	ServerVersions  map[ServerVersion]int     `json:"server_versions,omitempty"`
 }
 
 // AnalyzeCampaignFromFile analyzes OAST domains from a file and returns campaign statistics
@@ -54,14 +58,22 @@ func AnalyzeCampaignFromString(text string) *CampaignAnalysis {
 
 func analyzeCampaign(matches []OASTMatch, decoded []*DecodedOAST) *CampaignAnalysis {
 	analysis := &CampaignAnalysis{
-		TotalDomains: len(matches),
-		Campaigns:    make(map[string]*CampaignStats),
+		TotalDomains:   len(matches),
+		Campaigns:      make(map[string]*CampaignStats),
+		ClientTypes:    make(map[ClientType]int),
+		ServerVersions: make(map[ServerVersion]int),
 	}
 
 	machineIDSet := make(map[string]bool)
 	pidSet := make(map[uint16]bool)
 
 	for _, d := range decoded {
+		// Aggregate classification even for invalid (web client) domains
+		if d.Classification != nil {
+			analysis.ClientTypes[d.Classification.ClientType]++
+			analysis.ServerVersions[d.Classification.ServerVersion]++
+		}
+
 		if !d.Valid {
 			analysis.InvalidDomains++
 			continue
@@ -90,17 +102,24 @@ func analyzeCampaign(matches []OASTMatch, decoded []*DecodedOAST) *CampaignAnaly
 		stats, exists := analysis.Campaigns[campaignID]
 		if !exists {
 			stats = &CampaignStats{
-				CampaignID: campaignID,
-				FirstSeen:  d.Timestamp,
-				LastSeen:   d.Timestamp,
-				CounterMin: d.Counter,
-				CounterMax: d.Counter,
+				CampaignID:     campaignID,
+				FirstSeen:      d.Timestamp,
+				LastSeen:       d.Timestamp,
+				CounterMin:     d.Counter,
+				CounterMax:     d.Counter,
+				ClientTypes:    make(map[ClientType]int),
+				ServerVersions: make(map[ServerVersion]int),
 			}
 			analysis.Campaigns[campaignID] = stats
 		}
 
 		// Update campaign stats
 		stats.Count++
+
+		if d.Classification != nil {
+			stats.ClientTypes[d.Classification.ClientType]++
+			stats.ServerVersions[d.Classification.ServerVersion]++
+		}
 
 		if d.Timestamp.Before(stats.FirstSeen) {
 			stats.FirstSeen = d.Timestamp
@@ -177,6 +196,26 @@ func (a *CampaignAnalysis) FormatMarkdown() string {
 		sb.WriteString(fmt.Sprintf("- **First Seen:** %s\n", a.FirstSeen.Format(time.RFC3339)))
 		sb.WriteString(fmt.Sprintf("- **Last Seen:** %s\n", a.LastSeen.Format(time.RFC3339)))
 		sb.WriteString(fmt.Sprintf("- **Time Span:** %s\n", a.TimeSpan))
+	}
+
+	// Classification summary
+	if len(a.ClientTypes) > 0 {
+		sb.WriteString("\n## Classification\n\n")
+		sb.WriteString("**Client Types:** ")
+		var ctParts []string
+		for ct, count := range a.ClientTypes {
+			ctParts = append(ctParts, fmt.Sprintf("%s (%d)", ct, count))
+		}
+		sort.Strings(ctParts)
+		sb.WriteString(strings.Join(ctParts, ", ") + "\n")
+
+		sb.WriteString("**Server Versions:** ")
+		var svParts []string
+		for sv, count := range a.ServerVersions {
+			svParts = append(svParts, fmt.Sprintf("%s (%d)", sv, count))
+		}
+		sort.Strings(svParts)
+		sb.WriteString(strings.Join(svParts, ", ") + "\n")
 	}
 
 	// Machine IDs

--- a/pkg/roast/classify.go
+++ b/pkg/roast/classify.go
@@ -1,0 +1,256 @@
+// classify.go implements Interactsh domain classification by client type (CLI vs web)
+// and server version (v1.0.1 vs v1.0.2+). Uses character set analysis of the preamble
+// and zbase32 decoding of nonces to distinguish origins and extract session analytics.
+//
+// @decision: Classification uses character-set heuristics rather than attempting full
+// protocol fingerprinting. CLI preambles use base32hex [0-9a-v], web preambles use
+// letters-only [a-z] (including w,x,y,z which are outside base32hex). v1.0.1 detection
+// relies on nonce zbase32-decoding to a valid Unix timestamp (2020-2030 range), since
+// v1.0.2+ switched to crypto/rand nonces that produce random timestamps when decoded.
+package roast
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ClientType identifies the Interactsh client that generated the domain.
+type ClientType string
+
+const (
+	ClientCLI     ClientType = "cli"
+	ClientWeb     ClientType = "web"
+	ClientUnknown ClientType = "unknown"
+)
+
+// ServerVersion identifies the Interactsh server version based on nonce encoding.
+type ServerVersion string
+
+const (
+	VersionV101    ServerVersion = "v1.0.1"
+	VersionV102Plus ServerVersion = "v1.0.2+"
+	VersionUnknown ServerVersion = "unknown"
+)
+
+// NonceAnalysis contains decoded v1.0.1 nonce fields and derived session analytics.
+type NonceAnalysis struct {
+	NonceTimestamp  time.Time `json:"nonce_timestamp"`
+	NonceCounter    uint32    `json:"nonce_counter"`
+	SessionAge      string    `json:"session_age"`
+	SessionAgeSecs  int64     `json:"session_age_secs"`
+	DomainSequence  uint32    `json:"domain_sequence"`
+	Commentary      []string  `json:"commentary"`
+}
+
+// Classification contains client type, server version, and evidence for a domain.
+type Classification struct {
+	ClientType    ClientType    `json:"client_type"`
+	ServerVersion ServerVersion `json:"server_version"`
+	Confidence    string        `json:"confidence"`
+	Reasoning     []string      `json:"reasoning"`
+	Decodable     bool          `json:"decodable"`
+	NonceAnalysis *NonceAnalysis `json:"nonce_analysis,omitempty"`
+}
+
+// ClassifyDomain classifies an OAST subdomain by client type and server version.
+// cidTimestamp is the decoded XID timestamp (from preamble); pass zero time if unavailable.
+func ClassifyDomain(subdomain string, cidTimestamp time.Time) *Classification {
+	if len(subdomain) < 20 {
+		return &Classification{
+			ClientType:    ClientUnknown,
+			ServerVersion: VersionUnknown,
+			Confidence:    "low",
+			Reasoning:     []string{"subdomain too short for classification"},
+			Decodable:     false,
+		}
+	}
+
+	preamble := subdomain[:20]
+	var nonce string
+	if len(subdomain) > 20 {
+		nonce = subdomain[20:]
+	}
+
+	clientType, clientReasons, clientConf := classifyClient(preamble)
+	version, nonceAnalysis, versionReasons, versionConf := classifyVersion(nonce, cidTimestamp)
+
+	// Combine confidence: take the lower of the two
+	confidence := combineConfidence(clientConf, versionConf)
+
+	reasoning := append(clientReasons, versionReasons...)
+
+	return &Classification{
+		ClientType:    clientType,
+		ServerVersion: version,
+		Confidence:    confidence,
+		Reasoning:     reasoning,
+		Decodable:     clientType == ClientCLI,
+		NonceAnalysis: nonceAnalysis,
+	}
+}
+
+// classifyClient determines CLI vs web client from preamble character set.
+func classifyClient(preamble string) (ClientType, []string, string) {
+	preamble = strings.ToLower(preamble)
+	var reasons []string
+
+	hasDigit := false
+	hasHighAlpha := false // w, x, y, z — outside base32hex
+
+	for i := 0; i < len(preamble); i++ {
+		c := preamble[i]
+		if c >= '0' && c <= '9' {
+			hasDigit = true
+		}
+		if c >= 'w' && c <= 'z' {
+			hasHighAlpha = true
+		}
+	}
+
+	if hasDigit {
+		reasons = append(reasons, "preamble contains digits — CLI client (base32hex)")
+		return ClientCLI, reasons, "high"
+	}
+
+	if hasHighAlpha {
+		reasons = append(reasons, fmt.Sprintf("preamble contains letters outside base32hex [w-z] — web client"))
+		return ClientWeb, reasons, "high"
+	}
+
+	// All-letter preamble within [a-v] — ambiguous (valid in both charsets)
+	reasons = append(reasons, "preamble is all-letter [a-v] — ambiguous (valid base32hex and web)")
+	return ClientUnknown, reasons, "low"
+}
+
+// classifyVersion determines server version from nonce characteristics.
+func classifyVersion(nonce string, cidTimestamp time.Time) (ServerVersion, *NonceAnalysis, []string, string) {
+	if nonce == "" {
+		return VersionUnknown, nil, []string{"no nonce present"}, "low"
+	}
+
+	var reasons []string
+
+	// Check for web nonce markers: characters l, v, 0, 2 are NOT in zbase32 alphabet
+	hasWebNonceChars := false
+	for i := 0; i < len(nonce); i++ {
+		c := nonce[i]
+		if c == 'l' || c == 'v' || c == '0' || c == '2' {
+			hasWebNonceChars = true
+			break
+		}
+	}
+
+	if hasWebNonceChars {
+		reasons = append(reasons, "nonce contains characters outside zbase32 alphabet (l/v/0/2) — web nonce")
+		return VersionUnknown, nil, reasons, "high"
+	}
+
+	// Try to decode as v1.0.1 nonce (zbase32-encoded 8 bytes)
+	ts, counter, err := decodeV101Nonce(nonce)
+	if err != nil {
+		reasons = append(reasons, fmt.Sprintf("nonce zbase32 decode failed: %v — likely v1.0.2+ random", err))
+		return VersionV102Plus, nil, reasons, "medium"
+	}
+
+	// Check if timestamp is in plausible range (2020-01-01 to 2030-01-01)
+	minTS := uint32(1577836800) // 2020-01-01
+	maxTS := uint32(1893456000) // 2030-01-01
+
+	if ts >= minTS && ts <= maxTS {
+		reasons = append(reasons, fmt.Sprintf("nonce decodes to valid timestamp %s — v1.0.1", time.Unix(int64(ts), 0).UTC().Format(time.RFC3339)))
+		reasons = append(reasons, fmt.Sprintf("nonce counter=%d (domain sequence in process)", counter))
+
+		na := analyzeNonce(time.Unix(int64(ts), 0), counter, cidTimestamp)
+		return VersionV101, na, reasons, "high"
+	}
+
+	// Timestamp out of range — likely random bytes from v1.0.2+
+	reasons = append(reasons, fmt.Sprintf("nonce decodes to out-of-range timestamp %d — likely v1.0.2+ random", ts))
+	return VersionV102Plus, nil, reasons, "medium"
+}
+
+// decodeV101Nonce zbase32-decodes a nonce and extracts the 4-byte timestamp and 4-byte counter.
+func decodeV101Nonce(nonce string) (timestamp uint32, counter uint32, err error) {
+	bytes, err := zbase32Decode(nonce)
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(bytes) < 8 {
+		return 0, 0, fmt.Errorf("decoded nonce too short: %d bytes (need 8)", len(bytes))
+	}
+
+	timestamp = binary.BigEndian.Uint32(bytes[0:4])
+	counter = binary.BigEndian.Uint32(bytes[4:8])
+	return timestamp, counter, nil
+}
+
+// analyzeNonce generates analytical commentary comparing CID and nonce fields.
+func analyzeNonce(nonceTimestamp time.Time, nonceCounter uint32, cidTimestamp time.Time) *NonceAnalysis {
+	na := &NonceAnalysis{
+		NonceTimestamp: nonceTimestamp,
+		NonceCounter:   nonceCounter,
+		DomainSequence: nonceCounter,
+	}
+
+	// Session age: NonceTimestamp - CIDTimestamp
+	if !cidTimestamp.IsZero() {
+		delta := nonceTimestamp.Sub(cidTimestamp)
+		if delta < 0 {
+			delta = 0
+		}
+		na.SessionAgeSecs = int64(delta.Seconds())
+		na.SessionAge = formatDuration(delta)
+
+		// Commentary on session age
+		switch {
+		case delta < 2*time.Second:
+			na.Commentary = append(na.Commentary,
+				fmt.Sprintf("session_age=%s: domain generated at client startup (likely automated/scripted)", na.SessionAge))
+		case delta < time.Hour:
+			na.Commentary = append(na.Commentary,
+				fmt.Sprintf("session_age=%s: short client session", na.SessionAge))
+		default:
+			na.Commentary = append(na.Commentary,
+				fmt.Sprintf("session_age=%s: long-running client session", na.SessionAge))
+		}
+
+		// Check if timestamps match closely
+		if na.SessionAgeSecs <= 1 {
+			na.Commentary = append(na.Commentary,
+				"nonce_timestamp matches cid_timestamp: single-use client (generated one domain at init)")
+		}
+	}
+
+	// Commentary on counter
+	switch {
+	case nonceCounter == 0:
+		na.Commentary = append(na.Commentary,
+			"nonce_counter=0: first domain generated (counter pre-increment yields 1 normally; 0 suggests test or edge case)")
+	case nonceCounter == 1:
+		na.Commentary = append(na.Commentary,
+			"nonce_counter=1: first domain generated in this process (atomic.AddUint32 pre-increment)")
+	case nonceCounter <= 10:
+		na.Commentary = append(na.Commentary,
+			fmt.Sprintf("nonce_counter=%d: low-volume domain generation (%d URLs in session)", nonceCounter, nonceCounter))
+	case nonceCounter <= 100:
+		na.Commentary = append(na.Commentary,
+			fmt.Sprintf("nonce_counter=%d: moderate domain generation", nonceCounter))
+	default:
+		na.Commentary = append(na.Commentary,
+			fmt.Sprintf("nonce_counter=%d: high-volume domain generation (%d URLs in session)", nonceCounter, nonceCounter))
+	}
+
+	return na
+}
+
+// combineConfidence returns the lower of two confidence levels.
+func combineConfidence(a, b string) string {
+	order := map[string]int{"high": 3, "medium": 2, "low": 1}
+	av, bv := order[a], order[b]
+	if av <= bv {
+		return a
+	}
+	return b
+}

--- a/pkg/roast/classify_test.go
+++ b/pkg/roast/classify_test.go
@@ -1,0 +1,251 @@
+// classify_test.go tests the domain classification engine for client type detection
+// (CLI vs web), server version detection (v1.0.1 vs v1.0.2+), and nonce analysis.
+//
+// @decision: Tests use real-world-style subdomains rather than synthetic data to ensure
+// heuristics work against the actual character distributions seen in production domains.
+// The sample v1.0.1 domain "c58bduhe008dovpvhvug" + "cfemp9yyyyyyn" is from the project's
+// own test fixtures and produces a known-good timestamp of 2021-09-26.
+package roast
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClassifyClient(t *testing.T) {
+	tests := []struct {
+		name     string
+		preamble string
+		wantType ClientType
+		wantConf string
+	}{
+		{
+			name:     "CLI with digits",
+			preamble: "c58bduhe008dovpvhvug",
+			wantType: ClientCLI,
+			wantConf: "high",
+		},
+		{
+			name:     "web with w",
+			preamble: "abcdefghijklmnopqrwt",
+			wantType: ClientWeb,
+			wantConf: "high",
+		},
+		{
+			name:     "web with x",
+			preamble: "abcdefghijklmnopqrxt",
+			wantType: ClientWeb,
+			wantConf: "high",
+		},
+		{
+			name:     "web with y",
+			preamble: "abcdefghijklmnopqrys",
+			wantType: ClientWeb,
+			wantConf: "high",
+		},
+		{
+			name:     "web with z",
+			preamble: "abcdefghijklmnopqrzs",
+			wantType: ClientWeb,
+			wantConf: "high",
+		},
+		{
+			name:     "ambiguous a-v only letters",
+			preamble: "abcdefghijklmnopqrst",
+			wantType: ClientUnknown,
+			wantConf: "low",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, _, gotConf := classifyClient(tt.preamble)
+			if gotType != tt.wantType {
+				t.Errorf("classifyClient(%q) type=%q, want %q", tt.preamble, gotType, tt.wantType)
+			}
+			if gotConf != tt.wantConf {
+				t.Errorf("classifyClient(%q) conf=%q, want %q", tt.preamble, gotConf, tt.wantConf)
+			}
+		})
+	}
+}
+
+func TestClassifyVersion(t *testing.T) {
+	cidTime := time.Unix(1632679670, 0) // ~6 seconds before the nonce timestamp
+
+	t.Run("v1.0.1 nonce with valid timestamp", func(t *testing.T) {
+		// "cfemp9yyyyyyn" decodes to timestamp=1632679676, counter=1
+		version, na, _, conf := classifyVersion("cfemp9yyyyyyn", cidTime)
+		if version != VersionV101 {
+			t.Errorf("version=%q, want %q", version, VersionV101)
+		}
+		if conf != "high" {
+			t.Errorf("confidence=%q, want high", conf)
+		}
+		if na == nil {
+			t.Fatal("expected NonceAnalysis, got nil")
+		}
+		if na.NonceCounter != 1 {
+			t.Errorf("counter=%d, want 1", na.NonceCounter)
+		}
+		if na.DomainSequence != 1 {
+			t.Errorf("domain_sequence=%d, want 1", na.DomainSequence)
+		}
+		t.Logf("session_age=%s, commentary=%v", na.SessionAge, na.Commentary)
+	})
+
+	t.Run("no nonce", func(t *testing.T) {
+		version, na, _, conf := classifyVersion("", cidTime)
+		if version != VersionUnknown {
+			t.Errorf("version=%q, want %q", version, VersionUnknown)
+		}
+		if conf != "low" {
+			t.Errorf("confidence=%q, want low", conf)
+		}
+		if na != nil {
+			t.Error("expected nil NonceAnalysis")
+		}
+	})
+
+	t.Run("web nonce with l char", func(t *testing.T) {
+		version, _, _, conf := classifyVersion("abcdelghijklm", cidTime)
+		if version != VersionUnknown {
+			t.Errorf("version=%q, want %q", version, VersionUnknown)
+		}
+		if conf != "high" {
+			t.Errorf("confidence=%q, want high", conf)
+		}
+	})
+
+	t.Run("web nonce with 0 char", func(t *testing.T) {
+		version, _, _, _ := classifyVersion("abc0efghijklm", cidTime)
+		if version != VersionUnknown {
+			t.Errorf("version=%q, want %q", version, VersionUnknown)
+		}
+	})
+}
+
+func TestDecodeV101Nonce(t *testing.T) {
+	t.Run("valid nonce", func(t *testing.T) {
+		ts, counter, err := decodeV101Nonce("cfemp9yyyyyyn")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Timestamp should be ~2021-09-26
+		tsTime := time.Unix(int64(ts), 0)
+		if tsTime.Year() != 2021 {
+			t.Errorf("timestamp year=%d, want 2021", tsTime.Year())
+		}
+		if counter != 1 {
+			t.Errorf("counter=%d, want 1", counter)
+		}
+	})
+
+	t.Run("all zeros nonce", func(t *testing.T) {
+		// "yyyyyyyyyyyyy" = 13 y's = all zero bits
+		ts, counter, err := decodeV101Nonce("yyyyyyyyyyyyy")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ts != 0 {
+			t.Errorf("timestamp=%d, want 0", ts)
+		}
+		if counter != 0 {
+			t.Errorf("counter=%d, want 0", counter)
+		}
+	})
+}
+
+func TestClassifyDomain(t *testing.T) {
+	t.Run("CLI v1.0.1 domain", func(t *testing.T) {
+		c := ClassifyDomain("c58bduhe008dovpvhvugcfemp9yyyyyyn", time.Unix(1632679670, 0))
+		if c.ClientType != ClientCLI {
+			t.Errorf("client_type=%q, want cli", c.ClientType)
+		}
+		if c.ServerVersion != VersionV101 {
+			t.Errorf("server_version=%q, want v1.0.1", c.ServerVersion)
+		}
+		if !c.Decodable {
+			t.Error("expected decodable=true")
+		}
+		if c.NonceAnalysis == nil {
+			t.Fatal("expected nonce_analysis")
+		}
+		t.Logf("classification: %+v", c)
+	})
+
+	t.Run("too short", func(t *testing.T) {
+		c := ClassifyDomain("short", time.Time{})
+		if c.ClientType != ClientUnknown {
+			t.Errorf("client_type=%q, want unknown", c.ClientType)
+		}
+		if c.Decodable {
+			t.Error("expected decodable=false")
+		}
+	})
+
+	t.Run("web client domain", func(t *testing.T) {
+		c := ClassifyDomain("abcdefghijklmnopqrwtnonce123456", time.Time{})
+		if c.ClientType != ClientWeb {
+			t.Errorf("client_type=%q, want web", c.ClientType)
+		}
+		if c.Decodable {
+			t.Error("expected decodable=false for web client")
+		}
+	})
+}
+
+func TestAnalyzeNonce(t *testing.T) {
+	t.Run("startup domain", func(t *testing.T) {
+		cidTime := time.Unix(1632679676, 0)
+		nonceTime := time.Unix(1632679676, 0) // same second
+		na := analyzeNonce(nonceTime, 1, cidTime)
+
+		if na.SessionAgeSecs != 0 {
+			t.Errorf("session_age_secs=%d, want 0", na.SessionAgeSecs)
+		}
+		if len(na.Commentary) == 0 {
+			t.Error("expected commentary")
+		}
+		t.Logf("commentary: %v", na.Commentary)
+	})
+
+	t.Run("long session", func(t *testing.T) {
+		cidTime := time.Unix(1632679676, 0)
+		nonceTime := time.Unix(1632679676+7200, 0) // 2 hours later
+		na := analyzeNonce(nonceTime, 847, cidTime)
+
+		if na.SessionAgeSecs != 7200 {
+			t.Errorf("session_age_secs=%d, want 7200", na.SessionAgeSecs)
+		}
+		hasHighVolume := false
+		for _, c := range na.Commentary {
+			if len(c) > 0 {
+				hasHighVolume = true
+			}
+		}
+		if !hasHighVolume {
+			t.Error("expected commentary about high-volume generation")
+		}
+		t.Logf("commentary: %v", na.Commentary)
+	})
+}
+
+func TestCombineConfidence(t *testing.T) {
+	tests := []struct {
+		a, b, want string
+	}{
+		{"high", "high", "high"},
+		{"high", "medium", "medium"},
+		{"high", "low", "low"},
+		{"medium", "low", "low"},
+		{"low", "low", "low"},
+	}
+
+	for _, tt := range tests {
+		got := combineConfidence(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("combineConfidence(%q, %q)=%q, want %q", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/pkg/roast/decoder.go
+++ b/pkg/roast/decoder.go
@@ -43,6 +43,15 @@ func Decode(input string) (*DecodedOAST, error) {
 
 	// Validate preamble contains only base32hex characters
 	if !IsValidPreamble(preamble) {
+		// Check if this is a web client domain (all lowercase alpha)
+		if isAllLowerAlpha(preamble) {
+			if len(subdomain) > 20 {
+				result.Nonce = subdomain[20:]
+			}
+			result.Error = "web client domain: preamble is not base32hex-decodable"
+			result.Classification = ClassifyDomain(subdomain, time.Time{})
+			return result, fmt.Errorf(result.Error)
+		}
 		result.Error = "preamble contains invalid base32hex characters"
 		return result, fmt.Errorf(result.Error)
 	}
@@ -78,6 +87,10 @@ func Decode(input string) (*DecodedOAST, error) {
 	result.Campaign = preamble[6:11]
 
 	result.Valid = true
+
+	// Classify after successful CLI decode, using decoded CID timestamp for nonce analysis
+	result.Classification = ClassifyDomain(subdomain, result.Timestamp)
+
 	return result, nil
 }
 

--- a/pkg/roast/extractor.go
+++ b/pkg/roast/extractor.go
@@ -11,7 +11,7 @@ import (
 // Pattern to match OAST domains in text
 // Matches: subdomain (20+ base32hex chars + optional nonce) . known-domain
 var oastPattern = regexp.MustCompile(
-	`(?i)([a-v0-9]{20,}[a-z0-9_-]*)\.(oast\.(?:pro|live|site|online|fun|me)|interact\.sh|interactsh\.com)`,
+	`(?i)([a-z0-9]{20,}[a-z0-9_-]*)\.(oast\.(?:pro|live|site|online|fun|me)|interact\.sh|interactsh\.com)`,
 )
 
 // ExtractFromString finds all OAST domains in a string

--- a/pkg/roast/types.go
+++ b/pkg/roast/types.go
@@ -12,8 +12,9 @@ type DecodedOAST struct {
 	Nonce     string    `json:"nonce,omitempty"`     // The nonce portion (if present)
 	KSort     string    `json:"ksort"`               // First 6 chars of preamble (for K-sorting)
 	Campaign  string    `json:"campaign"`            // Chars 7-11 of preamble (campaign identifier)
-	Valid     bool      `json:"valid"`               // Whether decoding succeeded
-	Error     string    `json:"error,omitempty"`     // Error message if invalid
+	Valid          bool            `json:"valid"`                        // Whether decoding succeeded
+	Error          string          `json:"error,omitempty"`              // Error message if invalid
+	Classification *Classification `json:"classification,omitempty"`     // Client type and version classification
 }
 
 // OASTMatch represents an extracted OAST domain from text

--- a/pkg/roast/validate.go
+++ b/pkg/roast/validate.go
@@ -47,6 +47,48 @@ func KnownOASTDomains() []string {
 	return result
 }
 
+// IsValidOASTSubdomainExtended checks if a string looks like a valid OAST subdomain,
+// recognizing both CLI (base32hex) and web (all-alpha) client formats.
+// Returns validity and the detected client type.
+func IsValidOASTSubdomainExtended(s string) (bool, ClientType) {
+	if s == "" {
+		return false, ClientUnknown
+	}
+
+	subdomain := s
+	if idx := strings.Index(s, "."); idx > 0 {
+		subdomain = s[:idx]
+	}
+
+	if len(subdomain) < 20 {
+		return false, ClientUnknown
+	}
+
+	preamble := strings.ToLower(subdomain[:20])
+
+	// Check CLI: valid base32hex [0-9a-v]
+	if IsValidPreamble(preamble) {
+		return true, ClientCLI
+	}
+
+	// Check web: all lowercase alpha [a-z]
+	if isAllLowerAlpha(preamble) {
+		return true, ClientWeb
+	}
+
+	return false, ClientUnknown
+}
+
+// isAllLowerAlpha returns true if s contains only lowercase ASCII letters.
+func isAllLowerAlpha(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 'a' || s[i] > 'z' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
 // IsKnownOASTDomain checks if the given domain is a known OAST domain
 func IsKnownOASTDomain(domain string) bool {
 	domain = strings.ToLower(domain)

--- a/pkg/roast/zbase32.go
+++ b/pkg/roast/zbase32.go
@@ -1,0 +1,55 @@
+// zbase32.go decodes z-base-32 encoded strings into raw bytes.
+// Needed to extract timestamps and counters from v1.0.1 Interactsh nonces,
+// which encode 8 bytes (4-byte timestamp + 4-byte atomic counter) via zbase32.
+// Uses the zbase32Alphabet defined in types.go: "ybndrfg8ejkmcpqxot1uwisza345h769"
+//
+// @decision: Implement zbase32 decoder from scratch rather than importing a library.
+// The algorithm is trivial (5-bit-to-byte accumulator), the alphabet is already in types.go,
+// and adding a dependency for ~40 lines of code is not justified.
+package roast
+
+import "fmt"
+
+// zbase32Value returns the 5-bit value for a z-base-32 character.
+func zbase32Value(c byte) (int, bool) {
+	for i := 0; i < len(zbase32Alphabet); i++ {
+		if zbase32Alphabet[i] == c {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// zbase32Decode decodes a z-base-32 encoded string into bytes.
+// Each character encodes 5 bits. Output length is floor(len(s)*5/8).
+func zbase32Decode(s string) ([]byte, error) {
+	if len(s) == 0 {
+		return nil, fmt.Errorf("empty input")
+	}
+
+	totalBits := len(s) * 5
+	outLen := totalBits / 8
+
+	result := make([]byte, outLen)
+	var bitBuffer uint64
+	var bitCount int
+	byteIndex := 0
+
+	for i := 0; i < len(s); i++ {
+		val, ok := zbase32Value(s[i])
+		if !ok {
+			return nil, fmt.Errorf("invalid zbase32 character at position %d: %c", i, s[i])
+		}
+
+		bitBuffer = (bitBuffer << 5) | uint64(val)
+		bitCount += 5
+
+		for bitCount >= 8 && byteIndex < outLen {
+			bitCount -= 8
+			result[byteIndex] = byte((bitBuffer >> bitCount) & 0xFF)
+			byteIndex++
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/roast/zbase32_test.go
+++ b/pkg/roast/zbase32_test.go
@@ -1,0 +1,99 @@
+// zbase32_test.go tests the z-base-32 decoder used for v1.0.1 nonce extraction.
+// Covers character-to-value mapping, zero-byte decoding, known nonce values,
+// invalid input handling, and output length correctness.
+//
+// @decision: Tests use package-internal access (same package) to test unexported
+// zbase32Value and zbase32Decode directly, since they are implementation details
+// of the classification engine and not part of the public API.
+package roast
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestZbase32Value(t *testing.T) {
+	// 'y' is index 0, 'b' is index 1, 'n' is index 2, etc.
+	tests := []struct {
+		char byte
+		want int
+		ok   bool
+	}{
+		{'y', 0, true},
+		{'b', 1, true},
+		{'n', 2, true},
+		{'d', 3, true},
+		{'9', 31, true},
+		{'!', 0, false},
+		{'A', 0, false},
+	}
+
+	for _, tt := range tests {
+		got, ok := zbase32Value(tt.char)
+		if ok != tt.ok {
+			t.Errorf("zbase32Value(%c): ok=%v, want %v", tt.char, ok, tt.ok)
+		}
+		if ok && got != tt.want {
+			t.Errorf("zbase32Value(%c)=%d, want %d", tt.char, got, tt.want)
+		}
+	}
+}
+
+func TestZbase32Decode(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		_, err := zbase32Decode("")
+		if err == nil {
+			t.Fatal("expected error for empty input")
+		}
+	})
+
+	t.Run("invalid character", func(t *testing.T) {
+		_, err := zbase32Decode("yb!dr")
+		if err == nil {
+			t.Fatal("expected error for invalid character")
+		}
+	})
+
+	t.Run("all y chars decode to zero bytes", func(t *testing.T) {
+		// 'y' = 0 in zbase32, so "yyyyyyyy" (8 chars = 40 bits = 5 bytes of zeros)
+		result, err := zbase32Decode("yyyyyyyy")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 5 {
+			t.Fatalf("expected 5 bytes, got %d", len(result))
+		}
+		for i, b := range result {
+			if b != 0 {
+				t.Errorf("byte %d = %d, want 0", i, b)
+			}
+		}
+	})
+
+	t.Run("known v1.0.1 nonce decode", func(t *testing.T) {
+		// 13-char nonce = 65 bits = 8 bytes
+		nonce := "cfemp9yyyyyyn"
+		result, err := zbase32Decode(nonce)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 8 {
+			t.Fatalf("expected 8 bytes, got %d", len(result))
+		}
+		ts := binary.BigEndian.Uint32(result[0:4])
+		counter := binary.BigEndian.Uint32(result[4:8])
+		t.Logf("nonce %q -> timestamp=%d, counter=%d", nonce, ts, counter)
+	})
+
+	t.Run("round trip consistency", func(t *testing.T) {
+		input := "ybndrfg8ejkmcpqxo" // 17 chars = 85 bits = 10 bytes
+		result, err := zbase32Decode(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expectedLen := (17 * 5) / 8 // 10
+		if len(result) != expectedLen {
+			t.Errorf("expected %d bytes, got %d", expectedLen, len(result))
+		}
+	})
+}

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,8 @@
+// embed.go embeds the static web assets (HTML, CSS, JS) into the Go binary
+// via go:embed so the web UI requires no external files at runtime.
+package web
+
+import "embed"
+
+//go:embed static/*
+var staticFiles embed.FS

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -1,0 +1,152 @@
+// handlers.go implements the API endpoint handlers for the web UI.
+// Each handler accepts POST with JSON body, delegates to pkg/roast, and returns JSON.
+//
+// @decision: Handlers accept both {"input":"single string"} and {"input":"multi\nline"}
+// formats. This simplifies the client — textarea content is sent as-is, and the handler
+// splits on newlines for batch operations. Classification is always included in decode
+// results since it's now part of DecodedOAST.
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"codeberg.org/hrbrmstr/go-roast/pkg/roast"
+)
+
+type apiRequest struct {
+	Input string `json:"input"`
+}
+
+type apiError struct {
+	Error string `json:"error"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.Encode(v)
+}
+
+func readRequest(r *http.Request) (*apiRequest, error) {
+	var req apiRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+// POST /api/decode — decode one or more OAST domains
+func handleDecode(w http.ResponseWriter, r *http.Request) {
+	req, err := readRequest(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, apiError{Error: "invalid JSON: " + err.Error()})
+		return
+	}
+
+	lines := splitLines(req.Input)
+	if len(lines) == 0 {
+		writeJSON(w, http.StatusBadRequest, apiError{Error: "no input provided"})
+		return
+	}
+
+	results := roast.DecodeBatch(lines)
+	writeJSON(w, http.StatusOK, results)
+}
+
+// POST /api/classify — classify domains without full decode
+func handleClassify(w http.ResponseWriter, r *http.Request) {
+	req, err := readRequest(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, apiError{Error: "invalid JSON: " + err.Error()})
+		return
+	}
+
+	lines := splitLines(req.Input)
+	if len(lines) == 0 {
+		writeJSON(w, http.StatusBadRequest, apiError{Error: "no input provided"})
+		return
+	}
+
+	type classifyResult struct {
+		Domain         string               `json:"domain"`
+		Classification *roast.Classification `json:"classification"`
+	}
+
+	results := make([]classifyResult, len(lines))
+	for i, line := range lines {
+		subdomain := line
+		if idx := strings.Index(line, "."); idx > 0 {
+			subdomain = line[:idx]
+		}
+		subdomain = strings.ToLower(subdomain)
+
+		// Try decode for CID timestamp
+		var cidTimestamp time.Time
+		decoded, _ := roast.Decode(line)
+		if decoded != nil && decoded.Valid {
+			cidTimestamp = decoded.Timestamp
+		}
+
+		results[i] = classifyResult{
+			Domain:         line,
+			Classification: roast.ClassifyDomain(subdomain, cidTimestamp),
+		}
+	}
+
+	writeJSON(w, http.StatusOK, results)
+}
+
+// POST /api/extract — extract OAST domains from text
+func handleExtract(w http.ResponseWriter, r *http.Request) {
+	req, err := readRequest(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, apiError{Error: "invalid JSON: " + err.Error()})
+		return
+	}
+
+	if req.Input == "" {
+		writeJSON(w, http.StatusBadRequest, apiError{Error: "no input provided"})
+		return
+	}
+
+	matches, decoded := roast.ExtractAndDecode(req.Input)
+
+	result := map[string]interface{}{
+		"matches": matches,
+		"decoded": decoded,
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+// POST /api/analyze — campaign analysis
+func handleAnalyze(w http.ResponseWriter, r *http.Request) {
+	req, err := readRequest(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, apiError{Error: "invalid JSON: " + err.Error()})
+		return
+	}
+
+	if req.Input == "" {
+		writeJSON(w, http.StatusBadRequest, apiError{Error: "no input provided"})
+		return
+	}
+
+	analysis := roast.AnalyzeCampaignFromString(req.Input)
+	writeJSON(w, http.StatusOK, analysis)
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -1,0 +1,140 @@
+// handlers_test.go tests the web API handlers using httptest.
+// Covers decode, classify, extract, and analyze endpoints with valid input,
+// empty input, and malformed JSON.
+//
+// @decision: Use httptest.NewRequest + httptest.NewRecorder rather than spinning
+// up a real server. This keeps tests fast and deterministic.
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"codeberg.org/hrbrmstr/go-roast/pkg/roast"
+)
+
+func TestHandleDecode(t *testing.T) {
+	t.Run("valid CLI domain", func(t *testing.T) {
+		body := `{"input":"c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro"}`
+		req := httptest.NewRequest("POST", "/api/decode", strings.NewReader(body))
+		w := httptest.NewRecorder()
+
+		handleDecode(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", w.Code)
+		}
+
+		var results []*roast.DecodedOAST
+		if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+			t.Fatalf("failed to parse response: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+		if !results[0].Valid {
+			t.Error("expected valid=true")
+		}
+		if results[0].Classification == nil {
+			t.Error("expected classification to be present")
+		}
+		if results[0].Classification.ClientType != roast.ClientCLI {
+			t.Errorf("client_type=%q, want cli", results[0].Classification.ClientType)
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		body := `{"input":""}`
+		req := httptest.NewRequest("POST", "/api/decode", strings.NewReader(body))
+		w := httptest.NewRecorder()
+
+		handleDecode(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d, want 400", w.Code)
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/decode", strings.NewReader("not json"))
+		w := httptest.NewRecorder()
+
+		handleDecode(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d, want 400", w.Code)
+		}
+	})
+}
+
+func TestHandleClassify(t *testing.T) {
+	body := `{"input":"c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro"}`
+	req := httptest.NewRequest("POST", "/api/classify", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handleClassify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+
+	var results []struct {
+		Domain         string              `json:"domain"`
+		Classification *roast.Classification `json:"classification"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Classification.ClientType != roast.ClientCLI {
+		t.Errorf("client_type=%q, want cli", results[0].Classification.ClientType)
+	}
+}
+
+func TestHandleExtract(t *testing.T) {
+	body := `{"input":"Found domain c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro in logs"}`
+	req := httptest.NewRequest("POST", "/api/extract", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handleExtract(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if _, ok := result["matches"]; !ok {
+		t.Error("expected 'matches' in response")
+	}
+	if _, ok := result["decoded"]; !ok {
+		t.Error("expected 'decoded' in response")
+	}
+}
+
+func TestHandleAnalyze(t *testing.T) {
+	body := `{"input":"c58bduhe008dovpvhvugcfemp9yyyyyyn.oast.pro"}`
+	req := httptest.NewRequest("POST", "/api/analyze", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handleAnalyze(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+
+	var analysis roast.CampaignAnalysis
+	if err := json.Unmarshal(w.Body.Bytes(), &analysis); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if analysis.TotalDomains != 1 {
+		t.Errorf("total_domains=%d, want 1", analysis.TotalDomains)
+	}
+}

--- a/web/server.go
+++ b/web/server.go
@@ -1,0 +1,35 @@
+// server.go provides the HTTP server and routing for the web UI.
+// Serves embedded static files and API routes for domain decode/classify/extract/analyze.
+//
+// @decision: Use stdlib net/http and embed.FS rather than a framework. The API surface
+// is small (4 endpoints + static files) and adding a dependency like chi or gin is not
+// justified. The embed.FS approach means zero runtime file dependencies.
+package web
+
+import (
+	"fmt"
+	"io/fs"
+	"net/http"
+)
+
+// Serve starts the web server on the given address and port.
+func Serve(addr string, port int) error {
+	mux := http.NewServeMux()
+
+	// API routes
+	mux.HandleFunc("POST /api/decode", handleDecode)
+	mux.HandleFunc("POST /api/classify", handleClassify)
+	mux.HandleFunc("POST /api/extract", handleExtract)
+	mux.HandleFunc("POST /api/analyze", handleAnalyze)
+
+	// Static files
+	staticFS, err := fs.Sub(staticFiles, "static")
+	if err != nil {
+		return fmt.Errorf("failed to create static sub-filesystem: %w", err)
+	}
+	mux.Handle("/", http.FileServer(http.FS(staticFS)))
+
+	listenAddr := fmt.Sprintf("%s:%d", addr, port)
+	fmt.Printf("roast web UI: http://%s\n", listenAddr)
+	return http.ListenAndServe(listenAddr, mux)
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,0 +1,294 @@
+// app.js — vanilla JS client for roast web UI.
+// No external dependencies. Handles tab switching, file upload/drag-drop,
+// API calls, and result rendering with classification badges.
+//
+// @decision: Vanilla JS over a framework because the UI is a single page with
+// ~4 interactions. A framework would add build complexity for negligible benefit.
+
+(function() {
+  'use strict';
+
+  // DOM refs
+  const domainInput = document.getElementById('domain-input');
+  const actionSelect = document.getElementById('action-select');
+  const submitBtn = document.getElementById('submit-btn');
+  const resultsSection = document.getElementById('results-section');
+  const resultsContainer = document.getElementById('results-container');
+  const dropZone = document.getElementById('drop-zone');
+  const fileInput = document.getElementById('file-input');
+  const tabs = document.querySelectorAll('.tab');
+  const tabContents = document.querySelectorAll('.tab-content');
+
+  // Tab switching
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      tabs.forEach(t => t.classList.remove('active'));
+      tabContents.forEach(tc => tc.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+    });
+  });
+
+  // Drag and drop
+  dropZone.addEventListener('dragover', e => {
+    e.preventDefault();
+    dropZone.classList.add('dragover');
+  });
+
+  dropZone.addEventListener('dragleave', () => {
+    dropZone.classList.remove('dragover');
+  });
+
+  dropZone.addEventListener('drop', e => {
+    e.preventDefault();
+    dropZone.classList.remove('dragover');
+    const file = e.dataTransfer.files[0];
+    if (file) processFile(file);
+  });
+
+  fileInput.addEventListener('change', () => {
+    if (fileInput.files[0]) processFile(fileInput.files[0]);
+  });
+
+  dropZone.addEventListener('click', () => fileInput.click());
+
+  function processFile(file) {
+    const reader = new FileReader();
+    reader.onload = function(e) {
+      const text = e.target.result;
+      // Try to extract domains from CSV columns
+      const domains = extractDomainsFromCSV(text);
+      domainInput.value = domains.join('\n');
+      // Switch to paste tab to show loaded content
+      tabs[0].click();
+    };
+    reader.readAsText(file);
+  }
+
+  function extractDomainsFromCSV(text) {
+    const oastPattern = /[a-z0-9]{20,}[a-z0-9_-]*\.(?:oast\.(?:pro|live|site|online|fun|me)|interact\.sh|interactsh\.com)/gi;
+    const domains = new Set();
+    const matches = text.match(oastPattern);
+    if (matches) {
+      matches.forEach(m => domains.add(m.toLowerCase()));
+    }
+    // If no OAST pattern matches, return lines as-is (user might paste raw subdomains)
+    if (domains.size === 0) {
+      return text.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+    }
+    return Array.from(domains);
+  }
+
+  // Submit
+  submitBtn.addEventListener('click', async () => {
+    const input = domainInput.value.trim();
+    if (!input) return;
+
+    const action = actionSelect.value;
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Processing...';
+
+    try {
+      const resp = await fetch('/api/' + action, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input: input })
+      });
+
+      const data = await resp.json();
+
+      if (!resp.ok) {
+        showError(data.error || 'Request failed');
+        return;
+      }
+
+      renderResults(action, data);
+    } catch (err) {
+      showError('Network error: ' + err.message);
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Analyze';
+    }
+  });
+
+  function showError(msg) {
+    resultsSection.hidden = false;
+    resultsContainer.innerHTML = '<div class="error-msg">' + escapeHtml(msg) + '</div>';
+  }
+
+  function renderResults(action, data) {
+    resultsSection.hidden = false;
+
+    switch (action) {
+      case 'decode':
+        renderDecodeResults(data);
+        break;
+      case 'classify':
+        renderClassifyResults(data);
+        break;
+      case 'extract':
+        renderExtractResults(data);
+        break;
+      case 'analyze':
+        renderAnalyzeResults(data);
+        break;
+    }
+  }
+
+  function renderDecodeResults(results) {
+    if (!Array.isArray(results) || results.length === 0) {
+      resultsContainer.innerHTML = '<p>No results</p>';
+      return;
+    }
+
+    let html = '<table class="results-table"><thead><tr>';
+    html += '<th>Original</th><th>Valid</th><th>Client</th><th>Version</th>';
+    html += '<th>Conf</th><th>Timestamp</th><th>Machine</th><th>PID</th>';
+    html += '<th>Counter</th><th>Nonce</th>';
+    html += '</tr></thead><tbody>';
+
+    for (const r of results) {
+      const c = r.classification || {};
+      html += '<tr>';
+      html += '<td>' + escapeHtml(truncate(r.original, 35)) + '</td>';
+      html += '<td>' + (r.valid ? 'Y' : 'N') + '</td>';
+      html += '<td>' + clientBadge(c.client_type) + '</td>';
+      html += '<td>' + versionBadge(c.server_version) + '</td>';
+      html += '<td>' + confBadge(c.confidence) + '</td>';
+      html += '<td>' + (r.valid ? formatTimestamp(r.timestamp) : '') + '</td>';
+      html += '<td>' + escapeHtml(r.machine_id || '') + '</td>';
+      html += '<td>' + (r.pid || '') + '</td>';
+      html += '<td>' + (r.counter || '') + '</td>';
+      html += '<td>' + escapeHtml(r.nonce || '') + '</td>';
+      html += '</tr>';
+
+      // Nonce analysis row
+      if (c.nonce_analysis) {
+        const na = c.nonce_analysis;
+        html += '<tr><td colspan="10" class="nonce-detail">';
+        html += 'Nonce: ts=' + formatTimestamp(na.nonce_timestamp);
+        html += ' counter=' + na.nonce_counter;
+        html += ' session_age=' + escapeHtml(na.session_age || '');
+        if (na.commentary && na.commentary.length > 0) {
+          html += '<br>' + na.commentary.map(escapeHtml).join('<br>');
+        }
+        html += '</td></tr>';
+      }
+    }
+
+    html += '</tbody></table>';
+    resultsContainer.innerHTML = html;
+  }
+
+  function renderClassifyResults(results) {
+    if (!Array.isArray(results) || results.length === 0) {
+      resultsContainer.innerHTML = '<p>No results</p>';
+      return;
+    }
+
+    let html = '<table class="results-table"><thead><tr>';
+    html += '<th>Domain</th><th>Client</th><th>Version</th><th>Confidence</th>';
+    html += '<th>Decodable</th><th>Reasoning</th>';
+    html += '</tr></thead><tbody>';
+
+    for (const r of results) {
+      const c = r.classification || {};
+      html += '<tr>';
+      html += '<td>' + escapeHtml(truncate(r.domain, 40)) + '</td>';
+      html += '<td>' + clientBadge(c.client_type) + '</td>';
+      html += '<td>' + versionBadge(c.server_version) + '</td>';
+      html += '<td>' + confBadge(c.confidence) + '</td>';
+      html += '<td>' + (c.decodable ? 'Y' : 'N') + '</td>';
+      html += '<td>' + (c.reasoning || []).map(escapeHtml).join('; ') + '</td>';
+      html += '</tr>';
+    }
+
+    html += '</tbody></table>';
+    resultsContainer.innerHTML = html;
+  }
+
+  function renderExtractResults(data) {
+    const decoded = data.decoded || [];
+    if (decoded.length === 0) {
+      resultsContainer.innerHTML = '<p>No OAST domains found in text</p>';
+      return;
+    }
+    renderDecodeResults(decoded);
+  }
+
+  function renderAnalyzeResults(data) {
+    let html = '<div class="analysis-report">';
+    html += '<strong>Total Domains:</strong> ' + data.total_domains + '<br>';
+    html += '<strong>Valid:</strong> ' + data.valid_domains;
+    if (data.invalid_domains > 0) html += ' | <strong>Invalid:</strong> ' + data.invalid_domains;
+    html += '<br>';
+    html += '<strong>Campaigns:</strong> ' + data.unique_campaigns + '<br>';
+    html += '<strong>Machines:</strong> ' + data.unique_machines + '<br>';
+    html += '<strong>PIDs:</strong> ' + data.unique_pids + '<br>';
+
+    if (data.time_span) {
+      html += '<strong>Time Span:</strong> ' + escapeHtml(data.time_span) + '<br>';
+    }
+
+    // Classification summary
+    if (data.client_types) {
+      html += '<br><strong>Client Types:</strong> ';
+      html += Object.entries(data.client_types).map(([k, v]) => clientBadge(k) + ' ' + v).join(' ');
+      html += '<br>';
+    }
+    if (data.server_versions) {
+      html += '<strong>Server Versions:</strong> ';
+      html += Object.entries(data.server_versions).map(([k, v]) => versionBadge(k) + ' ' + v).join(' ');
+      html += '<br>';
+    }
+
+    // Campaign details
+    if (data.campaigns) {
+      for (const [id, stats] of Object.entries(data.campaigns)) {
+        html += '<br><strong>Campaign ' + escapeHtml(id) + ':</strong> ';
+        html += stats.count + ' domains, ';
+        html += 'counter ' + stats.counter_min + '-' + stats.counter_max;
+        html += '<br>';
+      }
+    }
+
+    html += '</div>';
+    resultsContainer.innerHTML = html;
+  }
+
+  // Helpers
+  function clientBadge(type_) {
+    if (!type_) return '';
+    const cls = { cli: 'badge-cli', web: 'badge-web', unknown: 'badge-unknown' }[type_] || 'badge-unknown';
+    return '<span class="badge ' + cls + '">' + escapeHtml(type_) + '</span>';
+  }
+
+  function versionBadge(ver) {
+    if (!ver) return '';
+    const cls = ver === 'v1.0.1' ? 'badge-v101' : ver === 'v1.0.2+' ? 'badge-v102' : 'badge-unknown';
+    return '<span class="badge ' + cls + '">' + escapeHtml(ver) + '</span>';
+  }
+
+  function confBadge(conf) {
+    if (!conf) return '';
+    const cls = { high: 'badge-high', medium: 'badge-medium', low: 'badge-low' }[conf] || 'badge-unknown';
+    return '<span class="badge ' + cls + '">' + escapeHtml(conf) + '</span>';
+  }
+
+  function formatTimestamp(ts) {
+    if (!ts) return '';
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return escapeHtml(ts);
+    return d.toISOString().replace('T', ' ').substring(0, 19);
+  }
+
+  function truncate(s, max) {
+    if (!s) return '';
+    return s.length > max ? s.substring(0, max - 3) + '...' : s;
+  }
+
+  function escapeHtml(s) {
+    if (!s) return '';
+    return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+})();

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>roast - OAST Domain Analyzer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+<h1>roast</h1>
+<p class="subtitle">Interactsh OAST Domain Analyzer</p>
+</header>
+
+<main>
+<section class="input-section">
+<div class="tabs">
+  <button class="tab active" data-tab="paste">Paste Domains</button>
+  <button class="tab" data-tab="upload">Upload CSV</button>
+</div>
+
+<div class="tab-content active" id="tab-paste">
+  <textarea id="domain-input" placeholder="Paste OAST domains or text containing domains (one per line)..." rows="6"></textarea>
+</div>
+
+<div class="tab-content" id="tab-upload">
+  <div class="drop-zone" id="drop-zone">
+    <p>Drop CSV file here or <label for="file-input" class="file-label">browse</label></p>
+    <input type="file" id="file-input" accept=".csv,.txt" hidden>
+    <p class="drop-hint">Domains will be auto-detected from CSV columns</p>
+  </div>
+</div>
+
+<div class="actions">
+  <select id="action-select">
+    <option value="decode">Decode</option>
+    <option value="classify">Classify</option>
+    <option value="extract">Extract &amp; Decode</option>
+    <option value="analyze">Campaign Analysis</option>
+  </select>
+  <button id="submit-btn">Analyze</button>
+</div>
+</section>
+
+<section class="results-section" id="results-section" hidden>
+<h2>Results</h2>
+<div id="results-container"></div>
+</section>
+</main>
+
+<footer>
+<p>roast v1.0.0 &mdash; <a href="https://codeberg.org/hrbrmstr/go-roast">source</a></p>
+</footer>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,0 +1,187 @@
+/* style.css — minimal system-font CSS with dark/light mode via prefers-color-scheme */
+
+:root {
+  --bg: #fff;
+  --fg: #1a1a1a;
+  --bg-alt: #f5f5f5;
+  --border: #ddd;
+  --accent: #2563eb;
+  --accent-fg: #fff;
+  --badge-cli: #16a34a;
+  --badge-web: #9333ea;
+  --badge-unknown: #6b7280;
+  --badge-v101: #ea580c;
+  --badge-v102: #0891b2;
+  --error: #dc2626;
+  --success: #16a34a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a1a;
+    --fg: #e5e5e5;
+    --bg-alt: #262626;
+    --border: #404040;
+    --accent: #3b82f6;
+    --badge-cli: #22c55e;
+    --badge-web: #a855f7;
+    --badge-unknown: #9ca3af;
+    --badge-v101: #fb923c;
+    --badge-v102: #22d3ee;
+    --error: #ef4444;
+    --success: #22c55e;
+  }
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+  background: var(--bg);
+  color: var(--fg);
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+header { margin-bottom: 1.5rem; }
+header h1 { font-size: 1.5rem; }
+header .subtitle { color: var(--badge-unknown); font-size: 0.875rem; }
+
+.input-section { margin-bottom: 1.5rem; }
+
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1rem;
+}
+
+.tab {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  color: var(--fg);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.875rem;
+  border-bottom: 2px solid transparent;
+}
+
+.tab.active { border-bottom-color: var(--accent); color: var(--accent); }
+.tab:hover { background: var(--bg-alt); }
+
+.tab-content { display: none; }
+.tab-content.active { display: block; }
+
+textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-alt);
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  resize: vertical;
+}
+
+.drop-zone {
+  border: 2px dashed var(--border);
+  border-radius: 4px;
+  padding: 2rem;
+  text-align: center;
+  cursor: pointer;
+}
+
+.drop-zone.dragover { border-color: var(--accent); background: var(--bg-alt); }
+.drop-hint { font-size: 0.75rem; color: var(--badge-unknown); margin-top: 0.5rem; }
+.file-label { color: var(--accent); cursor: pointer; text-decoration: underline; }
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+select, button {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.875rem;
+  background: var(--bg-alt);
+  color: var(--fg);
+  cursor: pointer;
+}
+
+#submit-btn {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+  font-weight: bold;
+}
+
+#submit-btn:hover { opacity: 0.9; }
+#submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.results-section { margin-top: 1rem; }
+.results-section h2 { font-size: 1.125rem; margin-bottom: 1rem; }
+
+.results-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+  overflow-x: auto;
+  display: block;
+}
+
+.results-table th, .results-table td {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--border);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.results-table th { background: var(--bg-alt); font-weight: bold; }
+.results-table tr:hover { background: var(--bg-alt); }
+
+.badge {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: #fff;
+}
+
+.badge-cli { background: var(--badge-cli); }
+.badge-web { background: var(--badge-web); }
+.badge-unknown { background: var(--badge-unknown); }
+.badge-v101 { background: var(--badge-v101); }
+.badge-v102 { background: var(--badge-v102); }
+.badge-high { background: var(--success); }
+.badge-medium { background: var(--badge-v101); }
+.badge-low { background: var(--badge-unknown); }
+
+.error-msg { color: var(--error); padding: 1rem; }
+
+.analysis-report { white-space: pre-wrap; font-size: 0.8125rem; }
+
+.nonce-detail {
+  font-size: 0.75rem;
+  color: var(--badge-unknown);
+  margin-top: 0.25rem;
+}
+
+footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.75rem;
+  color: var(--badge-unknown);
+}
+
+footer a { color: var(--accent); }


### PR DESCRIPTION
## Summary

- Add Interactsh domain classification engine detecting CLI vs web client origin and v1.0.1 vs v1.0.2+ server version using character-set heuristics and zbase32 nonce decoding
- Broaden extraction regex to capture web client domains (`[a-z0-9]` instead of `[a-v0-9]`) that were previously silently rejected
- Decode v1.0.1 nonces to extract session analytics: nonce timestamp, counter, session age, domain sequence, and analytical commentary
- Add embedded web UI (`roast serve`) with decode, classify, extract, and campaign analysis endpoints — no external JS/CSS dependencies
- Add `classify_oast` MCP tool for classification-only queries
- Update CSV and table output with ClientType, ServerVersion, Confidence, Nonce-Timestamp, Nonce-Counter columns

## New files

| File | Purpose |
|------|---------|
| `pkg/roast/zbase32.go` | z-base-32 decoder for v1.0.1 nonce extraction |
| `pkg/roast/classify.go` | Classification engine (client type + server version + nonce analysis) |
| `web/embed.go` | go:embed for static assets |
| `web/server.go` | HTTP server with API routes |
| `web/handlers.go` | API endpoint handlers |
| `web/static/*` | Single-page web UI (HTML + CSS + vanilla JS) |

## Test plan

- [x] `go test ./...` — all packages pass
- [x] CLI v1.0.1 domain decodes with classification + nonce analysis
- [x] Web client domain classified as `web` with `decodable=false`
- [x] Table output shows Nonce-Timestamp and Nonce-Counter columns
- [ ] `roast serve` — open http://127.0.0.1:8080, paste domains, verify results render with classification badges
- [ ] CSV upload via web UI with multi-column file

🤖 Generated with [Claude Code](https://claude.com/claude-code)